### PR TITLE
bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ gem : (https://rubygems.org/gems/jpush)
 
 Add this line to your application's Gemfile:
 
-    gem 'JPush'
+    gem 'jpush', :git => 'git://github.com/jpush/jpush-api-ruby-client.git'
 
 And then execute:
 

--- a/lib/jpush/model/push_payload.rb
+++ b/lib/jpush/model/push_payload.rb
@@ -9,7 +9,7 @@ The object you should build for sending a push.
       @platform = opts[:platform]
       @audience = opts[:audience]
       @message = opts[:message]
-      @options = opts[:options]
+      @options = opts[:options] || JPush::Options.new
       @notification = opts[:notification]
     end
 


### PR DESCRIPTION
1. gem 'JPush', can't found at https://rubygems.org/
2. 出现问题：无论在开发还是生产环境均不推送消息到ios。
       
      参考文档：http://docs.jpush.cn/display/dev/Push-API-v3      
      在默认情况下options["apns_production"]为false,但现在github上此版本中，初始状态是为空的，需要设置。