### PR TITLE
Fix fromResponse bug

### DIFF
--- a/lib/jpush/model/push_result.rb
+++ b/lib/jpush/model/push_result.rb
@@ -10,8 +10,8 @@ module JPush
       if wrapper.code != 200
         logger = Logger.new(STDOUT)
         logger.error('Error response from JPush server. Should review and fix it. ')
-        logger.info('HTTP Status:' + wrapper.code.to_s)
-        logger.info('Error Message:' + wrapper.error.to_s)
+        logger.info("HTTP Status: #{wrapper.code.to_s}")
+        logger.info("Error Message: #{wrapper.error.to_s}")
         raise JPush::ApiConnectionException.new(wrapper)
       end
       content = wrapper.getResponseContent


### PR DESCRIPTION
Logger#info 方法只有一个参数！

错误如下：

``` ruby
ArgumentError: wrong number of arguments (2 for 0..1)
    from /Users/tumayun/.rvm/rubies/ruby-2.1.3/lib/ruby/2.1.0/logger.rb:433:in `info'
    from /Users/tumayun/.rvm/gems/ruby-2.1.3@catchchat_server/gems/jpush-3.1.1/lib/jpush/model/push_result.rb:13:in `fromResponse'
    from /Users/tumayun/.rvm/gems/ruby-2.1.3@catchchat_server/gems/jpush-3.1.1/lib/jpush/push_client.rb:26:in `sendPush'
    from /Users/tumayun/.rvm/gems/ruby-2.1.3@catchchat_server/gems/jpush-3.1.1/lib/jpush/jpush_client.rb:43:in `sendPush'
```
